### PR TITLE
Huge PR fixing counter clockwise rendering of splines

### DIFF
--- a/main.c
+++ b/main.c
@@ -119,7 +119,7 @@ void render_spline_into_grid(void)
         solve_row(row, &solutions);
         for (size_t i = 0; i < solutions.count; ++i) {
             Solution s = solutions.items[i];
-            if (winding > 0) {
+            if (winding != 0) {
                 if (i > 0) {
                     Solution p = solutions.items[i-1];
                     size_t col1 = p.tx/cell_width;


### PR DESCRIPTION
To reproduce issue place the points as shown in the image, sadly nothing is rendered

<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/19f3a8de-0c20-4bc6-ba64-386d569d7f4e" />


After the fix counter clockwise rendering works!! 
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/ef814751-850c-4c96-abc6-f4ff231b1139" />


